### PR TITLE
enable LTO

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ repository = "https://github.com/lov3b/ecb-rates"
 rust-version = "1.83"
 categories = ["finance", "command-line-utilities"]
 
+[profile.release]
+codegen-units = 1
+lto = true
+
 [[bin]]
 name = "ecb-rates"
 path = "src/main.rs"


### PR DESCRIPTION
Enable LTO for release-builds as discussed in https://github.com/lov3b/ecb-rates/issues/1